### PR TITLE
Added scheduling feature

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -20,7 +20,7 @@ Usage
                          [--max-snapshots-per-volume SNAPSHOTS] [--snapshot-only]
                          [--remove-only] [--verbose] [--version]
                          [--tags TAGS [TAGS ...]] [--reverse-tags]
-                         [--scheduled SCHEDULED]
+                         [--label LABEL]
                          [--cross-account-number CROSS_ACCOUNT_NUMBER]
                          [--cross-account-role CROSS_ACCOUNT_ROLE]
 
@@ -47,12 +47,15 @@ Usage
       --reverse-tags        Do a reverse match on the passed in tags. E.g. --tag
                             Name:foo --reverse-tags will snapshot all instances
                             that do not have a `Name` tag with the value `foo`
-      --scheduled           SCHEDULED
-                            Only snapshot instances that match passed in scheduled
+      --label           LABEL
+                            Only snapshot instances that match passed in label
                             are created or deleted. Default: None.  Selected all
                             snapshot. You have the posibility of create a different
                             strategies for daily, weekly and monthly for example.
-                            Scheduled daily won't deleted scheduled weekly
+                            Label daily won't deleted label weekly. E.g.
+                              backup-monkey --max-snapshots-per-volume 6 --label daily
+                              backup-monkey --max-snapshots-per-volume 4 --label weekly
+                            You save 6 + 4 snapshots max. instead 4 or 6
       --cross-account-number CROSS_ACCOUNT_NUMBER
                             Do a cross-account snapshot (this is the account
                             number to do snapshots on). NOTE: This requires that

--- a/README.rst
+++ b/README.rst
@@ -20,6 +20,7 @@ Usage
                          [--max-snapshots-per-volume SNAPSHOTS] [--snapshot-only]
                          [--remove-only] [--verbose] [--version]
                          [--tags TAGS [TAGS ...]] [--reverse-tags]
+                         [--scheduled SCHEDULED]
                          [--cross-account-number CROSS_ACCOUNT_NUMBER]
                          [--cross-account-role CROSS_ACCOUNT_ROLE]
 
@@ -46,6 +47,12 @@ Usage
       --reverse-tags        Do a reverse match on the passed in tags. E.g. --tag
                             Name:foo --reverse-tags will snapshot all instances
                             that do not have a `Name` tag with the value `foo`
+      --scheduled           SCHEDULED
+                            Only snapshot instances that match passed in scheduled
+                            are created or deleted. Default: None.  Selected all
+                            snapshot. You have the posibility of create a different
+                            strategies for daily, weekly and monthly for example.
+                            Scheduled daily won't deleted scheduled weekly
       --cross-account-number CROSS_ACCOUNT_NUMBER
                             Do a cross-account snapshot (this is the account
                             number to do snapshots on). NOTE: This requires that
@@ -102,6 +109,15 @@ call the AWS APIs. You can pass your AWS credentials to Boto can by using a
 found here:
 
 http://boto.readthedocs.org/en/latest/boto_config_tut.html
+
+
+Run test
+--------
+
+::
+
+    python -m unittest -v tests.unit.test_exceptions
+    python -m unittest -v tests.unit.test_tags
 
 
 Warning

--- a/backup_monkey/cli.py
+++ b/backup_monkey/cli.py
@@ -24,7 +24,7 @@ from boto.utils import get_instance_metadata
 
 __all__ = ('run', )
 log = logging.getLogger(__name__)
-LIMIT_SCHEDULED = 32 # Scheduled is added to description when created snapshot.
+LIMIT_LABEL = 32 # Label is added to description when created snapshot.
                      # The description limit in aws is 255
 
 def _fail(message="Unknown failure", code=1):
@@ -49,8 +49,8 @@ def run():
                         help='Only snapshot instances that match passed in tags. E.g. --tag Name:foo will snapshot all instances with a tag `Name` and value is `foo`')
     parser.add_argument('--reverse-tags', action='store_true', default=False,
                         help='Do a reverse match on the passed in tags. E.g. --tag Name:foo --reverse-tags will snapshot all instances that do not have a `Name` tag with the value `foo`')
-    parser.add_argument('--scheduled', action='store',
-                        help='Only snapshot instances that match passed in scheduled are created or deleted. Default: None. Selected all snapshot. You have the posibility of create a different strategies for daily, weekly and monthly for example. Scheduled daily won\'t deleted scheduled weekly')
+    parser.add_argument('--label', action='store',
+                        help='Only snapshot instances that match passed in label are created or deleted. Default: None. Selected all snapshot. You have the posibility of create a different strategies for daily, weekly and monthly for example. Label daily won\'t deleted label weekly')
     parser.add_argument('--cross-account-number', action='store',
                         help='Do a cross-account snapshot (this is the account number to do snapshots on). NOTE: This requires that you pass in the --cross-account-role parameter. E.g. --cross-account-number 111111111111 --cross-account-role Snapshot')
     parser.add_argument('--cross-account-role', action='store',
@@ -67,8 +67,8 @@ def run():
     if args.reverse_tags and not args.tags:
         parser.error('The --tags parameter is required if you specify --reverse-tags (doing a blacklist filter)')
 
-    if args.scheduled and len(args.scheduled) > LIMIT_SCHEDULED:
-        parser.error('The --scheduled parameter lenght should be less than 32')
+    if args.label and len(args.label) > LIMIT_LABEL:
+        parser.error('The --label parameter lenght should be less than 32')
 
     Logging().configure(args.verbose)
 
@@ -93,7 +93,7 @@ def run():
                               args.max_snapshots_per_volume,
                               args.tags,
                               args.reverse_tags,
-                              args.scheduled,
+                              args.label,
                               args.cross_account_number,
                               args.cross_account_role)
         

--- a/backup_monkey/core.py
+++ b/backup_monkey/core.py
@@ -22,11 +22,11 @@ __all__ = ('BackupMonkey', 'Logging')
 log = logging.getLogger(__name__)
 
 class BackupMonkey(object):
-    def __init__(self, region, max_snapshots_per_volume, tags, reverse_tags, scheduled, cross_account_number, cross_account_role):
+    def __init__(self, region, max_snapshots_per_volume, tags, reverse_tags, label, cross_account_number, cross_account_role):
         self._region = region
         self._prefix = 'BACKUP_MONKEY'
-        if scheduled:
-            self._prefix += ' ' + scheduled
+        if label:
+            self._prefix += ' ' + label
         self._snapshots_per_volume = max_snapshots_per_volume
         self._tags = tags
         self._reverse_tags = reverse_tags

--- a/backup_monkey/core.py
+++ b/backup_monkey/core.py
@@ -22,9 +22,11 @@ __all__ = ('BackupMonkey', 'Logging')
 log = logging.getLogger(__name__)
 
 class BackupMonkey(object):
-    def __init__(self, region, max_snapshots_per_volume, tags, reverse_tags, cross_account_number, cross_account_role):
+    def __init__(self, region, max_snapshots_per_volume, tags, reverse_tags, scheduled, cross_account_number, cross_account_role):
         self._region = region
         self._prefix = 'BACKUP_MONKEY'
+        if scheduled:
+            self._prefix += ' ' + scheduled
         self._snapshots_per_volume = max_snapshots_per_volume
         self._tags = tags
         self._reverse_tags = reverse_tags

--- a/tests/unit/test_tags.py
+++ b/tests/unit/test_tags.py
@@ -1,11 +1,21 @@
 from unittest import TestCase
 import mock
-from backup_monkey.core import BackupMonkey 
+from backup_monkey.core import BackupMonkey
 
 class MockVolume(object):
     def __init__(self, id, tags={}):
         self.id = id
         self.tags = tags
+
+class MockSnapshot(object):
+    def __init__(self, id, description, start_time):
+        self.id = id
+        self.volume_id = 'vol-fb07ec3a'
+        self.description = description
+        self.start_time = start_time
+        self.status = 'completed'
+    def delete(self):
+        self.status = 'deleted'
 
 tag = ['name:foo']
 tag_or = ["name:['bar','baz']"]
@@ -39,7 +49,18 @@ match_tag_multiple = MockVolume('vol-d59b7114', params_to_dict(tag_multiple))
 
 volumes = [a, match_tag, match_tag_or_1, b, match_tag_or_2, match_tag_multiple]
 
+def create_snapshots():
+    snap_manual = MockSnapshot('snap-1a2b3c4d', 'no backup monkey', '2016-01-01T10:00:00.000Z')
+    snap_daily = MockSnapshot('snap-2a2b3c4d', 'BACKUP_MONKEY daily vol-fb07ec3a', '2016-01-01T11:00:00.000Z')
+    snap_weekly = MockSnapshot('snap-3a2b3c4d', 'BACKUP_MONKEY weekly vol-fb07ec3a', '2016-01-01T12:00:00.000Z')
+    snap_weekly2 = MockSnapshot('snap-4a2b3c4d', 'BACKUP_MONKEY weekly vol-fb07ec3a', '2016-01-01T13:00:00.000Z')
+    return [snap_manual, snap_daily, snap_weekly, snap_weekly2]
+
+
 class MockEC2Connection(object):
+    def __init__(self):
+        self.snapshots = create_snapshots()
+
     def get_all_volumes(self, filters=[]):
         if filters:
             if isinstance(filters['tag:name'], list):
@@ -48,6 +69,9 @@ class MockEC2Connection(object):
                 return [v for v in volumes if 'name' in v.tags and v.tags['name'] == filters['tag:name']]
         return volumes
 
+    def get_all_snapshots(self, owner='self'):
+        return self.snapshots
+
 def mock_get_connection():
     return MockEC2Connection() 
 
@@ -55,7 +79,7 @@ class TagsTest(TestCase):
 
     @mock.patch('backup_monkey.core.BackupMonkey.get_connection', side_effect=mock_get_connection)
     def setUp(self, mock):
-        self.backup_monkey = BackupMonkey('us-west-2', 3, [], None, None, None)
+        self.backup_monkey = BackupMonkey('us-west-2', 3, [], None, None, None, None)
 
     @mock.patch('backup_monkey.core.BackupMonkey.get_connection', side_effect=mock_get_connection)
     def test_instance(self, mock):
@@ -112,3 +136,41 @@ class TagsTest(TestCase):
         ret = self.backup_monkey.get_volumes_to_snapshot()
         assert len(ret) == 4
         assert ret == [a, match_tag_or_1, b, match_tag_or_2]
+
+class ScheduledTest(TestCase):
+
+    @mock.patch('backup_monkey.core.BackupMonkey.get_connection', side_effect=mock_get_connection)
+    def setUp(self, mock):
+        self.bm = BackupMonkey('us-west-2', 1, [], None, None, None, None)
+        self.bm_with_scheduled_daily = BackupMonkey('us-west-2', 1, [], None, 'daily', None, None)
+        self.bm_with_scheduled_weekly = BackupMonkey('us-west-2', 1, [], None, 'weekly', None, None)
+
+    @mock.patch('backup_monkey.core.BackupMonkey.get_connection', side_effect=mock_get_connection)
+    def test_without_scheduled(self, mock):
+        snaps = self.bm._conn.get_all_snapshots()
+        init_snapshot = filter(lambda x: x.status == 'completed', snaps)
+        self.bm.remove_old_snapshots()
+        snaps = self.bm._conn.get_all_snapshots()
+        end_snapshot = filter(lambda x: x.status == 'completed', snaps)
+        assert len(init_snapshot) == 4
+        assert len(end_snapshot) == 2
+
+    @mock.patch('backup_monkey.core.BackupMonkey.get_connection', side_effect=mock_get_connection)
+    def test_with_scheduled_daily(self, mock):
+        snaps = self.bm_with_scheduled_daily._conn.get_all_snapshots()
+        init_snapshot = filter(lambda x: x.status == 'completed', snaps)
+        self.bm_with_scheduled_daily.remove_old_snapshots()
+        snaps = self.bm_with_scheduled_daily._conn.get_all_snapshots()
+        end_snapshot = filter(lambda x: x.status == 'completed', snaps)
+        assert len(init_snapshot) == 4
+        assert len(end_snapshot) == 4
+
+    @mock.patch('backup_monkey.core.BackupMonkey.get_connection', side_effect=mock_get_connection)
+    def test_with_scheduled_weekly(self, mock):
+        snaps = self.bm_with_scheduled_weekly._conn.get_all_snapshots()
+        init_snapshot = filter(lambda x: x.status == 'completed', snaps)
+        self.bm_with_scheduled_weekly.remove_old_snapshots()
+        snaps = self.bm_with_scheduled_weekly._conn.get_all_snapshots()
+        end_snapshot = filter(lambda x: x.status == 'completed', snaps)
+        assert len(init_snapshot) == 4
+        assert len(end_snapshot) == 3

--- a/tests/unit/test_tags.py
+++ b/tests/unit/test_tags.py
@@ -137,16 +137,16 @@ class TagsTest(TestCase):
         assert len(ret) == 4
         assert ret == [a, match_tag_or_1, b, match_tag_or_2]
 
-class ScheduledTest(TestCase):
+class LabelTest(TestCase):
 
     @mock.patch('backup_monkey.core.BackupMonkey.get_connection', side_effect=mock_get_connection)
     def setUp(self, mock):
         self.bm = BackupMonkey('us-west-2', 1, [], None, None, None, None)
-        self.bm_with_scheduled_daily = BackupMonkey('us-west-2', 1, [], None, 'daily', None, None)
-        self.bm_with_scheduled_weekly = BackupMonkey('us-west-2', 1, [], None, 'weekly', None, None)
+        self.bm_with_label_daily = BackupMonkey('us-west-2', 1, [], None, 'daily', None, None)
+        self.bm_with_label_weekly = BackupMonkey('us-west-2', 1, [], None, 'weekly', None, None)
 
     @mock.patch('backup_monkey.core.BackupMonkey.get_connection', side_effect=mock_get_connection)
-    def test_without_scheduled(self, mock):
+    def test_without_label(self, mock):
         snaps = self.bm._conn.get_all_snapshots()
         init_snapshot = filter(lambda x: x.status == 'completed', snaps)
         self.bm.remove_old_snapshots()
@@ -156,21 +156,21 @@ class ScheduledTest(TestCase):
         assert len(end_snapshot) == 2
 
     @mock.patch('backup_monkey.core.BackupMonkey.get_connection', side_effect=mock_get_connection)
-    def test_with_scheduled_daily(self, mock):
-        snaps = self.bm_with_scheduled_daily._conn.get_all_snapshots()
+    def test_with_label_daily(self, mock):
+        snaps = self.bm_with_label_daily._conn.get_all_snapshots()
         init_snapshot = filter(lambda x: x.status == 'completed', snaps)
-        self.bm_with_scheduled_daily.remove_old_snapshots()
-        snaps = self.bm_with_scheduled_daily._conn.get_all_snapshots()
+        self.bm_with_label_daily.remove_old_snapshots()
+        snaps = self.bm_with_label_daily._conn.get_all_snapshots()
         end_snapshot = filter(lambda x: x.status == 'completed', snaps)
         assert len(init_snapshot) == 4
         assert len(end_snapshot) == 4
 
     @mock.patch('backup_monkey.core.BackupMonkey.get_connection', side_effect=mock_get_connection)
-    def test_with_scheduled_weekly(self, mock):
-        snaps = self.bm_with_scheduled_weekly._conn.get_all_snapshots()
+    def test_with_label_weekly(self, mock):
+        snaps = self.bm_with_label_weekly._conn.get_all_snapshots()
         init_snapshot = filter(lambda x: x.status == 'completed', snaps)
-        self.bm_with_scheduled_weekly.remove_old_snapshots()
-        snaps = self.bm_with_scheduled_weekly._conn.get_all_snapshots()
+        self.bm_with_label_weekly.remove_old_snapshots()
+        snaps = self.bm_with_label_weekly._conn.get_all_snapshots()
         end_snapshot = filter(lambda x: x.status == 'completed', snaps)
         assert len(init_snapshot) == 4
         assert len(end_snapshot) == 3


### PR DESCRIPTION
I add in this PR the options of scheduling different strategies.

For example, if you want to save daily backup and weekly backup with different --max-snapshots-per-volume for each one, thi PR permit it. An example:

```
backup-monkey --region us-west-1 --max-snapshots-per-volume 6 --scheduled daily
backup-monkey --region us-west-1 --max-snapshots-per-volume 4 --scheduled weekly
```

You save 6 + 4 snapshots max.
