### PR TITLE
implement request ratelimiting

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -66,6 +66,9 @@ Usage
                             The name of the role that backup-monkey will assume
                             when doing a cross-account snapshot. E.g. --cross-
                             account-role Snapshot
+      --ratelimit RATELIMIT
+                            Time to wait in seconds between subsequent requests to
+                            the AWS API. E.g. --ratelimit 5
 
 Examples
 --------

--- a/backup_monkey/cli.py
+++ b/backup_monkey/cli.py
@@ -55,6 +55,8 @@ def run():
                         help='Do a cross-account snapshot (this is the account number to do snapshots on). NOTE: This requires that you pass in the --cross-account-role parameter. E.g. --cross-account-number 111111111111 --cross-account-role Snapshot')
     parser.add_argument('--cross-account-role', action='store',
                         help='The name of the role that backup-monkey will assume when doing a cross-account snapshot. E.g. --cross-account-role Snapshot')
+    parser.add_argument('--ratelimit', action='store', default=0,
+                        help='Time to wait in seconds between subsequent requests to the AWS API. E.g. --ratelimit 5')
 
     args = parser.parse_args()
 
@@ -95,7 +97,8 @@ def run():
                               args.reverse_tags,
                               args.label,
                               args.cross_account_number,
-                              args.cross_account_role)
+                              args.cross_account_role,
+                              args.ratelimit)
         
         if not args.remove_only:
             monkey.snapshot_volumes()

--- a/backup_monkey/core.py
+++ b/backup_monkey/core.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import logging
+from time import sleep
 
 from boto.exception import NoAuthHandlerFound
 from boto import ec2
@@ -22,7 +23,7 @@ __all__ = ('BackupMonkey', 'Logging')
 log = logging.getLogger(__name__)
 
 class BackupMonkey(object):
-    def __init__(self, region, max_snapshots_per_volume, tags, reverse_tags, label, cross_account_number, cross_account_role):
+    def __init__(self, region, max_snapshots_per_volume, tags, reverse_tags, label, cross_account_number, cross_account_role, ratelimit):
         self._region = region
         self._prefix = 'BACKUP_MONKEY'
         if label:
@@ -32,6 +33,7 @@ class BackupMonkey(object):
         self._reverse_tags = reverse_tags
         self._cross_account_number = cross_account_number
         self._cross_account_role = cross_account_role
+        self._ratelimit = ratelimit
         self._conn = self.get_connection()
 
     def get_connection(self):
@@ -116,6 +118,7 @@ class BackupMonkey(object):
             description = ' '.join(description_parts)
             log.info('Creating snapshot of %s: %s', volume.id, description)
             volume.create_snapshot(description)
+            sleep(self._ratelimit)
         return True
 
 


### PR DESCRIPTION
I've been hitting AWS ratelimits using backup-monkey, at which point the backup job fails. This implements a simple solution by allowing users to set a delay between requests. An alternative  approach would be to catch the `BotoServerError` and retry exponentially. It may actually make sense to support both options, but in the meantime this should help.